### PR TITLE
Fix iOS and add mobile touch events

### DIFF
--- a/src/components/capture.css
+++ b/src/components/capture.css
@@ -65,6 +65,7 @@
   padding: 15px;
   font-size: 20px;
   margin-top: 10px;
+  user-select: none;
 }
 
 .btnCapture:hover {

--- a/src/components/capture.js
+++ b/src/components/capture.js
@@ -150,6 +150,7 @@ export default class Home extends Component {
                 style={{ display: image || renderProgress ? 'none' : 'block' }}
                 ref={(c) => (this._video = c)}
                 srcObject={stream}
+                playsinline
               />
               {!image &&
                 renderProgress > 0 && (
@@ -187,6 +188,8 @@ export default class Home extends Component {
                   })}
                   onMouseDown={this.startCapture}
                   onMouseUp={this.stopCapture}
+                  onTouchStart={this.startCapture}
+                  onTouchEnd={this.stopCapture}
                 >
                   {captureStart ? 'Recording' : 'Hold to record'}
                 </button>


### PR DESCRIPTION
iOS needs `playsinline` in order to render video per https://github.com/webrtc/samples/issues/929. Touch events are also good to have along with disallowing the selection of that button's text

